### PR TITLE
Update results for Chrome 21 and Firefox 14 over IE8.

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,8 +66,8 @@
 				<th>Media Query</th>
 				<th>iPhone 4.3</th>
 				<th>Android Tablet</th>
-				<th>Chrome 19</th>
-				<th>IE 8</th>
+				<th>Chrome 21</th>
+				<th>Firefox 14</th>
 				<th>IE 9</th>
 				<th>Opera 11</th>
 				<th>Opera Mobile</th>


### PR DESCRIPTION
Hi Scott,

Chrome 21 still attempted the download.
Swapped Firefox 14 for IE8, as the site says "today's browsers"  :D

Lunchtime tinkering ftw.

Cheers,
Brian
